### PR TITLE
Add AutoTrader notifier bot

### DIFF
--- a/.github/workflows/run_bot.yml
+++ b/.github/workflows/run_bot.yml
@@ -1,0 +1,30 @@
+name: Run AutoTrader Bot
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt
+      - name: Run bot
+        run: python autotrader_bot.py
+        env:
+          GMAIL_USER: ${{ secrets.GMAIL_USER }}
+          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          TWILIO_SID: ${{ secrets.TWILIO_SID }}
+          TWILIO_TOKEN: ${{ secrets.TWILIO_TOKEN }}
+          TWILIO_FROM: ${{ secrets.TWILIO_FROM }}
+          TWILIO_TO: ${{ secrets.TWILIO_TO }}
+          SEARCH_URL: ${{ secrets.SEARCH_URL }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: seen_listings
+          path: seen_listings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python
+__pycache__/
+*.pyc
+
+# Environment
+.env
+
+# Runtime data
+seen_listings.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# autotrader_notifier
+# AutoTrader Notifier
+
+This project provides a small Python script that checks an AutoTrader
+search page and notifies you of new listings via Gmail and Twilio SMS.
+
+Configuration values are read from environment variables or a `.env`
+file. To create the `.env` file interactively run:
+
+```bash
+python autotrader_bot.py --setup
+```
+
+The following values are required:
+
+- `SEARCH_URL` – AutoTrader search results URL
+- `GMAIL_USER` – Gmail address used to send emails
+- `GMAIL_APP_PASSWORD` – Gmail app password
+- `TWILIO_SID` – Twilio account SID
+- `TWILIO_TOKEN` – Twilio auth token
+- `TWILIO_FROM` – Twilio phone number to send from
+- `TWILIO_TO` – Phone number to receive SMS messages
+
+`seen_listings.json` is used to keep track of listings that have already
+been processed. The GitHub Actions workflow uploads this file as a build
+artifact so state is preserved between runs.
+
+To run locally after creating `.env`:
+
+```bash
+pip install -r requirements.txt
+python autotrader_bot.py
+```

--- a/autotrader_bot.py
+++ b/autotrader_bot.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Simple AutoTrader notifier.
+
+Fetches search results from AutoTrader and sends notifications via
+Gmail and Twilio for new listings. Credentials and configuration are
+read from environment variables or a .env file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from email.mime.text import MIMEText
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+from twilio.rest import Client
+
+# Mapping of required environment variables and friendly descriptions
+ENV_VARS = {
+    "SEARCH_URL": "AutoTrader search results URL",
+    "GMAIL_USER": "Gmail address",
+    "GMAIL_APP_PASSWORD": "Gmail app password",
+    "TWILIO_SID": "Twilio account SID",
+    "TWILIO_TOKEN": "Twilio auth token",
+    "TWILIO_FROM": "Twilio 'from' phone number",
+    "TWILIO_TO": "Destination phone number",
+}
+
+SEEN_FILE = Path("seen_listings.json")
+
+
+def interactive_setup() -> None:
+    """Prompt the user for credentials and save them to .env."""
+    print("Interactive setup for AutoTrader notifier.\nValues will be written to .env")
+    if Path(".env").exists():
+        ans = input(".env already exists. Overwrite? [y/N]: ").strip().lower()
+        if ans != "y":
+            print("Setup aborted.")
+            return
+    lines = []
+    for key, desc in ENV_VARS.items():
+        value = input(f"{desc} ({key}): ").strip()
+        lines.append(f"{key}={value}")
+    Path(".env").write_text("\n".join(lines))
+    print(".env file written.")
+
+
+def load_config() -> dict:
+    """Load environment variables and ensure all are present."""
+    load_dotenv()
+    config = {}
+    missing = []
+    for key in ENV_VARS:
+        val = os.getenv(key)
+        if not val:
+            missing.append(key)
+        config[key] = val
+    if missing:
+        raise RuntimeError(f"Missing environment variables: {', '.join(missing)}")
+    return config
+
+
+def load_seen() -> set[str]:
+    if SEEN_FILE.exists():
+        try:
+            return set(json.loads(SEEN_FILE.read_text()))
+        except json.JSONDecodeError:
+            return set()
+    return set()
+
+
+def save_seen(seen: set[str]) -> None:
+    SEEN_FILE.write_text(json.dumps(sorted(seen), indent=2))
+
+
+def fetch_listings(url: str) -> list[dict[str, str]]:
+    """Fetch and parse listings from AutoTrader search results."""
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    listings = []
+    for div in soup.select("div[data-listing-id]"):
+        lid = div.get("data-listing-id")
+        title = div.get_text(" ", strip=True)[:80]
+        listing_url = f"https://www.autotrader.com/cars-for-sale/vehicledetails.xhtml?listingId={lid}"
+        listings.append({"id": lid, "title": title, "url": listing_url})
+    return listings
+
+
+def send_email(cfg: dict, msg: str) -> None:
+    mime = MIMEText(msg)
+    mime["Subject"] = "New AutoTrader listing"
+    mime["From"] = cfg["GMAIL_USER"]
+    mime["To"] = cfg["GMAIL_USER"]
+
+    import smtplib
+
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
+        smtp.login(cfg["GMAIL_USER"], cfg["GMAIL_APP_PASSWORD"])
+        smtp.sendmail(cfg["GMAIL_USER"], [cfg["GMAIL_USER"]], mime.as_string())
+
+
+def send_sms(cfg: dict, msg: str) -> None:
+    client = Client(cfg["TWILIO_SID"], cfg["TWILIO_TOKEN"])
+    client.messages.create(body=msg, from_=cfg["TWILIO_FROM"], to=cfg["TWILIO_TO"])
+
+
+def notify(cfg: dict, listing: dict) -> None:
+    msg = f"{listing['title']}\n{listing['url']}"
+    try:
+        send_email(cfg, msg)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to send email: {exc}")
+    try:
+        send_sms(cfg, msg)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to send SMS: {exc}")
+
+
+def main() -> None:
+    if "--setup" in sys.argv:
+        interactive_setup()
+        return
+
+    cfg = load_config()
+    seen = load_seen()
+    listings = fetch_listings(cfg["SEARCH_URL"])
+    new = [l for l in listings if l["id"] not in seen]
+
+    for listing in new:
+        notify(cfg, listing)
+        seen.add(listing["id"])
+
+    save_seen(seen)
+    print(f"Processed {len(new)} new listings.")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+twilio
+python-dotenv


### PR DESCRIPTION
## Summary
- implement `autotrader_bot.py` for checking listings
- add interactive setup that writes credentials to `.env`
- create GitHub workflow to run bot and store `seen_listings.json`
- document setup and usage

## Testing
- `python -m py_compile autotrader_bot.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_6847f90475b88329ab6c95e08fcda9e9