### PR TITLE
Update setup instructions for cloud-only workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,48 +3,30 @@
 This project provides a small Python script that checks an AutoTrader
 search page and notifies you of new listings via Gmail and Twilio SMS.
 
-## Step-by-step setup
+## Setup using GitHub Actions
 
-The instructions below walk through the entire process as if you have
-never used Python before. Follow them in order and you will have a working notifier on your own computer.
+The notifier can run entirely in the cloud with no local Python
+installation. Follow these steps to configure the workflow:
 
-1. **Install Python** – Download Python 3.10 or later from
-   [python.org](https://www.python.org/downloads/). During installation
-   make sure to tick the option that adds Python to your `PATH`.
-2. **Download the project** – Click the green **Code** button on this
-   page and choose **Download ZIP**. Once downloaded, extract the ZIP
-   file to a folder you can easily find, for example your Desktop.
-3. **Open a terminal** – On Windows you can use *Command Prompt*. On
-   macOS or Linux open the *Terminal* application. Use the `cd` command
-   to move into the folder you extracted, e.g.:
-
-   ```bash
-   cd path/to/autotrader_notifier
-   ```
-4. **Install required Python packages** – Run:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
-5. **Create configuration file** – Run the setup command and answer the
-   prompts. A `.env` file will be written with your answers.
-
-   ```bash
-   python autotrader_bot.py --setup
-   ```
-   The script will ask for the values listed in the **Required information** section below.
-6. **Run the notifier** – After the `.env` file is created start the
-   script:
-
-   ```bash
-   python autotrader_bot.py
-   ```
-   New listings will trigger an email and SMS and will be recorded in
-`seen_listings.json` so you are not alerted twice.
+1. **Fork the repository** – Use the **Fork** button on GitHub to create
+   your own copy.
+2. **Add repository secrets** – In your fork open
+   *Settings → Secrets → Actions* and create secrets for the values listed
+   in the **Required information** section below. The workflow will export
+   them as environment variables when it runs.
+3. **Configure the schedule** – The workflow file is located at
+   `.github/workflows/run_bot.yml`. Edit the `cron` expression under the
+   `schedule` key to control how often the bot runs, or trigger it
+   manually using the *Run workflow* button.
+4. **Start the workflow** – Once your secrets are saved, the next
+   scheduled run (or a manual run) will execute `autotrader_bot.py` in the
+   GitHub Actions environment. New listings trigger an email and SMS and
+   are recorded in `seen_listings.json` which is uploaded as a build
+   artifact so state is preserved between runs.
 
 ### Required information
 
-During setup you will be prompted for:
+Add these secrets to your repository:
 - `SEARCH_URL` – AutoTrader search results URL
 - `GMAIL_USER` – Gmail address used to send emails
 - `GMAIL_APP_PASSWORD` – Gmail app password
@@ -55,10 +37,4 @@ During setup you will be prompted for:
 
 The GitHub Actions workflow uploads the `seen_listings.json` file as a
 build artifact so state is preserved between runs.
-
-To run the notifier again later just run:
-
-```bash
-python autotrader_bot.py
-```
 


### PR DESCRIPTION
## Summary
- update README to describe running the notifier via GitHub Actions
- remove local Python instructions

## Testing
- `python -m py_compile autotrader_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6859f4d9d81083298b5b6eb138a09c87