### PR TITLE
Update README with interactive setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ triggered a notification.
 Summary
 
 This setup allows you to monitor new AutoTrader listings completely in the cloud — with no code to install or run on your own computer.
+
+Local Setup
+
+If you prefer to run the script yourself, execute `python autotrader_bot.py --setup` once.
+It will prompt for your Gmail, Twilio, and search URL credentials, then save them in a
+`.env` file for subsequent runs.


### PR DESCRIPTION
## Summary
- document optional local setup with `python autotrader_bot.py --setup`

## Testing
- `python -m py_compile autotrader_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685a177294e88329b8160b493defc3f8