### PR TITLE
Add User-Agent header to fetch_listings

### DIFF
--- a/autotrader_bot.py
+++ b/autotrader_bot.py
@@ -131,7 +131,8 @@ def archive_listing(listing: dict) -> None:
 
 def fetch_listings(url: str) -> list[dict[str, str]]:
     """Fetch and parse listings from AutoTrader search results."""
-    resp = requests.get(url, timeout=15)
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = requests.get(url, headers=headers, timeout=15)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
     listings = []

--- a/tests/test_fetch_listings.py
+++ b/tests/test_fetch_listings.py
@@ -74,7 +74,7 @@ class DummyResponse:
         pass
 
 
-def dummy_get(url: str, timeout: int = 15):
+def dummy_get(url: str, timeout: int = 15, headers=None):
     return DummyResponse(SAMPLE_HTML)
 
 


### PR DESCRIPTION
## Summary
- send a User-Agent header when fetching listings to avoid 403 errors
- adjust unit tests to accept the new header parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a28fab6d483298aaf179e81e7d40f