### PR TITLE
Improve listing selector

### DIFF
--- a/tests/test_fetch_listings.py
+++ b/tests/test_fetch_listings.py
@@ -74,7 +74,7 @@ class DummyResponse:
         pass
 
 
-def dummy_get(url: str, timeout: int = 15):
+def dummy_get(url: str, timeout: int = 15, headers: dict | None = None):
     return DummyResponse(SAMPLE_HTML)
 
 


### PR DESCRIPTION
## Summary
- widen search to any element with `data-listing-id` when fetching listings, falling back to the old selector

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a28fab6d483298aaf179e81e7d40f