### PR TITLE
Add debug option to dump fetched HTML

### DIFF
--- a/tests/test_fetch_listings.py
+++ b/tests/test_fetch_listings.py
@@ -74,7 +74,7 @@ class DummyResponse:
         pass
 
 
-def dummy_get(url: str, timeout: int = 15):
+def dummy_get(url: str, timeout: int = 15, headers: dict | None = None):
     return DummyResponse(SAMPLE_HTML)
 
 


### PR DESCRIPTION
## Summary
- add optional `dump_html` argument to `fetch_listings` and print the page HTML when enabled
- support `--dump-html` flag in `main`
- clarify that a User-Agent header prevents HTTP 403 errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a28fab6d483298aaf179e81e7d40f